### PR TITLE
Feat: uniform errors

### DIFF
--- a/.changeset/hip-moose-arrive.md
+++ b/.changeset/hip-moose-arrive.md
@@ -1,0 +1,5 @@
+---
+'@soluble/cache-interop': minor
+---
+
+Refactor previousError into previous for exceptions

--- a/.changeset/sharp-rocks-explode.md
+++ b/.changeset/sharp-rocks-explode.md
@@ -5,4 +5,4 @@
 '@soluble/cache-redis': minor
 ---
 
-Add support for uniform error messages
+Uniform error messages

--- a/.changeset/sharp-rocks-explode.md
+++ b/.changeset/sharp-rocks-explode.md
@@ -1,0 +1,8 @@
+---
+'@soluble/cache-e2e-tests': minor
+'@soluble/cache-interop': minor
+'@soluble/cache-ioredis': minor
+'@soluble/cache-redis': minor
+---
+
+Add support for uniform error messages

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
 
+/.vscode/settings.json

--- a/packages/cache-e2e-tests/test/all-adapters-error.test.ts
+++ b/packages/cache-e2e-tests/test/all-adapters-error.test.ts
@@ -1,0 +1,133 @@
+import { CacheException, CacheInterface, ConnectedCacheInterface, ErrorFormatter } from '@soluble/cache-interop';
+import { IoRedisCacheAdapter } from '@soluble/cache-ioredis';
+import { RedisCacheAdapter } from '@soluble/cache-redis';
+import IORedis from 'ioredis';
+
+type ConnectableCache = CacheInterface & ConnectedCacheInterface<unknown>;
+
+const adapters = [
+  [
+    'IoRedisCacheAdapter',
+    async (port: number) => {
+      return new IoRedisCacheAdapter({
+        connection: new IORedis({
+          host: 'localhost',
+          port,
+          maxRetriesPerRequest: 0,
+        }),
+      });
+    },
+  ],
+  /**
+  [
+    'RedisCacheAdapter/Redis5',
+    async (dsn: string) => {
+      return new RedisCacheAdapter({
+        connection: dsn,
+      });
+    },
+  ],
+   */
+] as [name: string, factory: (port: number) => Promise<ConnectableCache>][];
+
+const invalidPortForTests = 65440;
+
+describe.each(adapters)('Adapter: %s', (name, adapterFactory) => {
+  let cache: ConnectableCache;
+  beforeAll(async () => {
+    cache = await adapterFactory(invalidPortForTests);
+  });
+  afterAll(async () => {
+    await cache.getConnection().quit();
+  });
+
+  describe('when cache connection is invalid', () => {
+    const errFmt = new ErrorFormatter(name);
+    describe('Adapter.get()', () => {
+      it('should return error with proper message', async () => {
+        const { error } = await cache.get('k');
+        expect(error).toBeInstanceOf(CacheException);
+        const expected = errFmt.getMsg('get', 'READ_ERROR');
+        expect(error?.message).toMatch(expected);
+      });
+    });
+    describe('Adapter.getMultiple()', () => {
+      it('should return error with proper message', async () => {
+        const item = (await cache.getMultiple(['k'])).get('k');
+        expect(item).not.toBeUndefined();
+        const { error } = item as any;
+        expect(error).toBeInstanceOf(CacheException);
+        const expected = errFmt.getMsg('get', 'READ_ERROR');
+        expect(error?.message).toMatch(expected);
+      });
+    });
+    describe('Adapter.has()', () => {
+      it('should return undefined and call onError', async () => {
+        let err: CacheException | null = null;
+        const error = await cache.has('k', {
+          onError: (e) => {
+            err = e;
+          },
+        });
+        expect(error).toStrictEqual(undefined);
+        const expected = errFmt.getMsg('has', 'COMMAND_ERROR');
+        expect((err as any)?.message).toMatch(expected);
+      });
+    });
+
+    describe('Adapter.set()', () => {
+      it('should return error with proper message', async () => {
+        const error = await cache.set('k', 'cool');
+        expect(error).toBeInstanceOf(CacheException);
+        const expected = errFmt.getMsg('set', 'WRITE_ERROR');
+        expect((error as any)?.message).toMatch(expected);
+      });
+    });
+
+    describe('Adapter.setMultiple()', () => {
+      it('should return undefined', async () => {
+        //let err: CacheException | null = null;
+        const firstRet = (await cache.setMultiple([['k', 'value']])).get('k');
+        expect(firstRet).not.toBeUndefined();
+        expect(firstRet).toBeInstanceOf(CacheException);
+        const expected = errFmt.getMsg('set', 'WRITE_ERROR');
+        expect((firstRet as any)?.message).toMatch(expected);
+      });
+    });
+    describe('Adapter.delete()', () => {
+      it('should return error with proper message', async () => {
+        const error = await cache.delete('k');
+        expect(error).toBeInstanceOf(CacheException);
+        const expected = errFmt.getMsg('delete', 'WRITE_ERROR');
+        expect((error as any)?.message).toMatch(expected);
+      });
+    });
+
+    describe('Adapter.deleteMultiple()', () => {
+      it('should return error with proper message', async () => {
+        const firstErr = (await cache.deleteMultiple(['k'])).get('k');
+        expect(firstErr).toBeInstanceOf(CacheException);
+        const expected = errFmt.getMsg('delete', 'WRITE_ERROR');
+        expect((firstErr as any)?.message).toMatch(expected);
+      });
+    });
+
+    describe('Adapter.clear()', () => {
+      it('should return error with proper message', async () => {
+        const error = await cache.clear();
+        expect(error).toBeInstanceOf(CacheException);
+        const expected = errFmt.getMsg('clear', 'COMMAND_ERROR');
+        expect((error as any)?.message).toMatch(expected);
+      });
+    });
+
+    describe('Adapter.getOrSet()', () => {
+      it('should return error with proper message', async () => {
+        const { error } = await cache.getOrSet('k', () => 'cool');
+        expect(error).toBeInstanceOf(CacheException);
+        const expected = errFmt.getMsg('get', 'READ_ERROR');
+        expect((error as any)?.message).toMatch(expected);
+      });
+    });
+  });
+});

--- a/packages/cache-e2e-tests/test/all-adapters-error.test.ts
+++ b/packages/cache-e2e-tests/test/all-adapters-error.test.ts
@@ -27,6 +27,8 @@ const adapters = [
           host: 'localhost',
           port: port,
           max_attempts: 1,
+          /** Will make the client fails early */
+          enable_offline_queue: false,
           connect_timeout: 10,
           disable_resubscribing: true,
           no_ready_check: true,
@@ -44,7 +46,7 @@ describe.each(adapters)('Adapter: %s', (name, adapterFactory) => {
     try {
       cache = await adapterFactory(invalidPortForTests);
     } catch (e) {
-      console.log('Cannot connect anyway !!', cache);
+      console.error('Cannot connect anyway !!', cache);
     }
   });
   afterAll(async () => {

--- a/packages/cache-interop/src/adapter/abstract-cache-adapter.ts
+++ b/packages/cache-interop/src/adapter/abstract-cache-adapter.ts
@@ -104,7 +104,7 @@ export abstract class AbstractCacheAdapter<TBase = string, KBase extends CacheKe
           key: key,
           error: new CacheProviderException({
             message: 'Could not execute async function provider',
-            previousError: e,
+            previous: e,
           }),
         });
       }

--- a/packages/cache-interop/src/adapter/abstract-cache-adapter.ts
+++ b/packages/cache-interop/src/adapter/abstract-cache-adapter.ts
@@ -10,7 +10,7 @@ import {
 } from '../cache.interface';
 import { CacheItemInterface } from '../cache-item.interface';
 import { executeValueProviderFn } from '../utils';
-import { CacheException, CacheProviderException } from '../exceptions';
+import { CacheException } from '../exceptions';
 import { getGetOrSetCacheDisabledParams } from '../utils/cache-options-utils';
 import { CacheItemFactory } from '../cache-item.factory';
 import { Guards } from '../validation/guards';
@@ -31,7 +31,7 @@ export abstract class AbstractCacheAdapter<TBase = string, KBase extends CacheKe
 
   get errorHelper(): ErrorHelper {
     if (!this._errorHelper) {
-      this._errorHelper = new ErrorHelper(this.adapterName);
+      this._errorHelper = new ErrorHelper(this.adapterName ?? 'AbstractCacheAdapter');
     }
     return this._errorHelper;
   }
@@ -102,10 +102,7 @@ export abstract class AbstractCacheAdapter<TBase = string, KBase extends CacheKe
       } catch (e) {
         return CacheItemFactory.fromErr({
           key: key,
-          error: new CacheProviderException({
-            message: 'Could not execute async function provider',
-            previous: e,
-          }),
+          error: this.errorHelper.getCacheProviderException(['getOrSet', key], e),
         });
       }
     } else {

--- a/packages/cache-interop/src/adapter/abstract-cache-adapter.ts
+++ b/packages/cache-interop/src/adapter/abstract-cache-adapter.ts
@@ -14,6 +14,7 @@ import { CacheException, CacheProviderException } from '../exceptions';
 import { getGetOrSetCacheDisabledParams } from '../utils/cache-options-utils';
 import { CacheItemFactory } from '../cache-item.factory';
 import { Guards } from '../validation/guards';
+import { ErrorHelper } from '../error/error-helper';
 
 const defaultGetOrSetOptions: GetOrSetOptions = {
   disableCache: {
@@ -24,6 +25,17 @@ const defaultGetOrSetOptions: GetOrSetOptions = {
 
 export abstract class AbstractCacheAdapter<TBase = string, KBase extends CacheKey = CacheKey>
   implements CacheInterface<TBase, KBase> {
+  protected _errorHelper: ErrorHelper | undefined;
+
+  abstract adapterName: string;
+
+  get errorHelper(): ErrorHelper {
+    if (!this._errorHelper) {
+      this._errorHelper = new ErrorHelper(this.adapterName);
+    }
+    return this._errorHelper;
+  }
+
   abstract set<T = TBase, K extends KBase = KBase>(
     key: K,
     value: T | CacheValueProviderFn<T>,

--- a/packages/cache-interop/src/adapter/abstract-cache-adapter.ts
+++ b/packages/cache-interop/src/adapter/abstract-cache-adapter.ts
@@ -77,7 +77,7 @@ export abstract class AbstractCacheAdapter<TBase = string, KBase extends CacheKe
     const { disableCache = false, ...setOptions } = { ...defaultGetOrSetOptions, ...(options ?? {}) };
     const { read: disableRead, write: disableWrite } = getGetOrSetCacheDisabledParams(disableCache);
     const item = await this.get<T, K>(key, { disableCache: disableRead });
-    if (item.data !== null) {
+    if (item.data !== null || item.error instanceof CacheException) {
       return item;
     }
 

--- a/packages/cache-interop/src/adapter/map-cache-adapter.ts
+++ b/packages/cache-interop/src/adapter/map-cache-adapter.ts
@@ -31,8 +31,10 @@ export class MapCacheAdapter<TBase = string, KBase extends CacheKey = CacheKey>
   private map: Map<KBase, { expiresAt: number; data: unknown }>;
   private dateProvider: DateProvider;
   private evictionPolicy: EvictionPolicyInterface;
+  public readonly adapterName: string;
   constructor(options?: Options) {
     super();
+    this.adapterName = MapCacheAdapter.prototype.constructor.name;
     const { evictionPolicy } = { ...defaultOptions, ...(options ?? {}) };
     this.map = new Map();
     this.evictionPolicy = evictionPolicy;

--- a/packages/cache-interop/src/adapter/map-cache-adapter.ts
+++ b/packages/cache-interop/src/adapter/map-cache-adapter.ts
@@ -76,7 +76,7 @@ export class MapCacheAdapter<TBase = string, KBase extends CacheKey = CacheKey>
     options?: SetOptions
   ): Promise<boolean | CacheException> => {
     if (!Guards.isValidCacheKey(key)) {
-      return new InvalidCacheKeyException(key);
+      return new InvalidCacheKeyException({ key });
     }
     const { disableCache = false, ttl = 0 } = options ?? {};
     if (disableCache) {
@@ -101,7 +101,7 @@ export class MapCacheAdapter<TBase = string, KBase extends CacheKey = CacheKey>
 
   has = async <K extends KBase = KBase>(key: K, options?: HasOptions): Promise<boolean | undefined> => {
     if (!Guards.isValidCacheKey(key)) {
-      options?.onError?.(new InvalidCacheKeyException(key));
+      options?.onError?.(new InvalidCacheKeyException({ key }));
       return undefined;
     }
     const { disableCache = false } = options ?? {};
@@ -117,7 +117,7 @@ export class MapCacheAdapter<TBase = string, KBase extends CacheKey = CacheKey>
 
   delete = async <K extends KBase = KBase>(key: K, options?: DeleteOptions): Promise<boolean | CacheException> => {
     if (!Guards.isValidCacheKey(key)) {
-      return new InvalidCacheKeyException(key);
+      return new InvalidCacheKeyException({ key });
     }
     const { disableCache = false } = options ?? {};
     if (disableCache) {

--- a/packages/cache-interop/src/adapter/map-cache-adapter.ts
+++ b/packages/cache-interop/src/adapter/map-cache-adapter.ts
@@ -91,7 +91,7 @@ export class MapCacheAdapter<TBase = string, KBase extends CacheKey = CacheKey>
       } catch (e) {
         // @todo decide what do do, a cache miss ?
         return new CacheProviderException({
-          previousError: e,
+          previous: e,
           message: "Can't fetch the provided function",
         });
       }

--- a/packages/cache-interop/src/error/__tests__/error-formatter.test.ts
+++ b/packages/cache-interop/src/error/__tests__/error-formatter.test.ts
@@ -2,6 +2,12 @@ import { ErrorFormatter } from '../error-formatter';
 
 describe('ErrorFormatter', () => {
   describe('getMsg', () => {
+    it('should truncate detail', () => {
+      const fmt = new ErrorFormatter('RedisAdapter', 2);
+      expect(fmt.getMsg('get', 'READ_ERROR', '12345')).toBe(
+        "[RedisAdapter.get()] READ_ERROR: Can't read from the cache (12...)"
+      );
+    });
     it('should add cache adapter name, set method and message', () => {
       const fmt = new ErrorFormatter('RedisAdapter');
       expect(fmt.getMsg('get', 'READ_ERROR')).toBe("[RedisAdapter.get()] READ_ERROR: Can't read from the cache");

--- a/packages/cache-interop/src/error/__tests__/error-formatter.test.ts
+++ b/packages/cache-interop/src/error/__tests__/error-formatter.test.ts
@@ -1,0 +1,20 @@
+import { ErrorFormatter } from '../error-formatter';
+
+describe('ErrorFormatter', () => {
+  describe('getMsg', () => {
+    it('should add cache adapter name, set method and message', () => {
+      const fmt = new ErrorFormatter('RedisAdapter');
+      expect(fmt.getMsg('get', 'READ_ERROR')).toBe("[RedisAdapter.get()] READ_ERROR: Can't read from the cache");
+    });
+    it('should allow detail', () => {
+      const fmt = new ErrorFormatter('Adapter');
+      expect(fmt.getMsg('get', 'READ_ERROR', 'cause...')).toBe(
+        "[Adapter.get()] READ_ERROR: Can't read from the cache (cause...)"
+      );
+    });
+    it('should allow replacing message', () => {
+      const fmt = new ErrorFormatter('Adapter');
+      expect(fmt.getMsg('get', 'READ_ERROR', null, 'Hello')).toBe('[Adapter.get()] READ_ERROR: Hello');
+    });
+  });
+});

--- a/packages/cache-interop/src/error/__tests__/error-formatter.test.ts
+++ b/packages/cache-interop/src/error/__tests__/error-formatter.test.ts
@@ -12,12 +12,19 @@ describe('ErrorFormatter', () => {
       const fmt = new ErrorFormatter('RedisAdapter');
       expect(fmt.getMsg('get', 'READ_ERROR')).toBe("[RedisAdapter.get()] READ_ERROR: Can't read from the cache");
     });
-    it('should allow detail', () => {
+    it('should accept a detail parameter', () => {
       const fmt = new ErrorFormatter('Adapter');
       expect(fmt.getMsg('get', 'READ_ERROR', 'cause...')).toBe(
         "[Adapter.get()] READ_ERROR: Can't read from the cache (cause...)"
       );
     });
+    it('should add the key in method if provided', () => {
+      const fmt = new ErrorFormatter('Adapter');
+      expect(fmt.getMsg(['get', 'key'], 'READ_ERROR', 'cause...')).toBe(
+        "[Adapter.get(key)] READ_ERROR: Can't read from the cache (cause...)"
+      );
+    });
+
     it('should allow replacing message', () => {
       const fmt = new ErrorFormatter('Adapter');
       expect(fmt.getMsg('get', 'READ_ERROR', null, 'Hello')).toBe('[Adapter.get()] READ_ERROR: Hello');

--- a/packages/cache-interop/src/error/error-formatter.ts
+++ b/packages/cache-interop/src/error/error-formatter.ts
@@ -2,13 +2,15 @@ import { CacheInterface } from '../cache.interface';
 import { ErrorReasons, errorReasons } from './error.constants';
 import { Guards } from '../validation/guards';
 type Method = keyof CacheInterface;
+type MethodWithKey = [method: Method, key: string];
 
 export class ErrorFormatter {
   constructor(public readonly adapterName: string, private readonly limitDetail = 40) {}
-  getMsg = (method: Method, reason: ErrorReasons, detail?: string | null, msg?: string): string => {
+  getMsg = (method: Method | MethodWithKey, reason: ErrorReasons, detail?: string | null, msg?: string): string => {
     const message = msg || errorReasons[reason];
     const extra = Guards.isNonEmptyString(detail) ? `(${this.truncate(detail)})` : '';
-    return `[${this.adapterName}.${method}()] ${reason}: ${message} ${extra}`.trim();
+    const [m, k = ''] = typeof method === 'string' ? [method] : method;
+    return `[${this.adapterName}.${m}(${k})] ${reason}: ${message} ${extra}`.trim();
   };
   private truncate(detail: string) {
     if (detail.length > this.limitDetail) {

--- a/packages/cache-interop/src/error/error-formatter.ts
+++ b/packages/cache-interop/src/error/error-formatter.ts
@@ -1,0 +1,13 @@
+import { CacheInterface } from '../cache.interface';
+import { ErrorReasons, errorReasons } from './error.constants';
+import { Guards } from '../validation/guards';
+type Method = keyof CacheInterface;
+
+export class ErrorFormatter {
+  constructor(public readonly adapterName: string) {}
+  getMsg = (method: Method, reason: ErrorReasons, detail?: string | null, msg?: string): string => {
+    const message = msg || errorReasons[reason];
+    const extra = Guards.isNonEmptyString(detail) ? `(${detail})` : '';
+    return `[${this.adapterName}.${method}()] ${reason}: ${message} ${extra}`.trim();
+  };
+}

--- a/packages/cache-interop/src/error/error-formatter.ts
+++ b/packages/cache-interop/src/error/error-formatter.ts
@@ -1,12 +1,15 @@
 import { CacheInterface } from '../cache.interface';
 import { ErrorReasons, errorReasons } from './error.constants';
 import { Guards } from '../validation/guards';
-type Method = keyof CacheInterface;
-type MethodWithKey = [method: Method, key: string];
+
+export type Method = keyof CacheInterface;
+export type MethodWithKey = [method: Method, key: string];
+
+export type CallerMethod = Method | MethodWithKey;
 
 export class ErrorFormatter {
   constructor(public readonly adapterName: string, private readonly limitDetail = 40) {}
-  getMsg = (method: Method | MethodWithKey, reason: ErrorReasons, detail?: string | null, msg?: string): string => {
+  getMsg = (method: CallerMethod, reason: ErrorReasons, detail?: string | null, msg?: string): string => {
     const message = msg || errorReasons[reason];
     const extra = Guards.isNonEmptyString(detail) ? `(${this.truncate(detail)})` : '';
     const [m, k = ''] = typeof method === 'string' ? [method] : method;

--- a/packages/cache-interop/src/error/error-formatter.ts
+++ b/packages/cache-interop/src/error/error-formatter.ts
@@ -4,10 +4,16 @@ import { Guards } from '../validation/guards';
 type Method = keyof CacheInterface;
 
 export class ErrorFormatter {
-  constructor(public readonly adapterName: string) {}
+  constructor(public readonly adapterName: string, private readonly limitDetail = 40) {}
   getMsg = (method: Method, reason: ErrorReasons, detail?: string | null, msg?: string): string => {
     const message = msg || errorReasons[reason];
-    const extra = Guards.isNonEmptyString(detail) ? `(${detail})` : '';
+    const extra = Guards.isNonEmptyString(detail) ? `(${this.truncate(detail)})` : '';
     return `[${this.adapterName}.${method}()] ${reason}: ${message} ${extra}`.trim();
   };
+  private truncate(detail: string) {
+    if (detail.length > this.limitDetail) {
+      return detail.substring(0, this.limitDetail) + '...';
+    }
+    return detail;
+  }
 }

--- a/packages/cache-interop/src/error/error-helper.ts
+++ b/packages/cache-interop/src/error/error-helper.ts
@@ -1,0 +1,42 @@
+import { ErrorFormatter } from './error-formatter';
+import { CacheInterface } from '../cache.interface';
+import { ErrorReasons } from './error.constants';
+import { CacheException, InvalidCacheKeyException, UnsupportedValueException } from '../exceptions';
+
+export class ErrorHelper {
+  private readonly formatter: ErrorFormatter;
+  constructor(private readonly adapterName: string) {
+    this.formatter = new ErrorFormatter(this.adapterName);
+  }
+
+  formatMsg(method: keyof CacheInterface, reason: ErrorReasons, detail?: string | null): string {
+    return this.formatter.getMsg(method, reason, detail);
+  }
+
+  getInvalidCacheKeyException(method: keyof CacheInterface, key: unknown): InvalidCacheKeyException {
+    return new InvalidCacheKeyException({ key: key, message: this.formatMsg(method, 'INVALID_KEY') });
+  }
+
+  getCacheProviderException(method: keyof CacheInterface, previous?: Error): CacheException {
+    return new CacheException({
+      message: this.formatMsg(method, 'EXECUTE_ASYNC_ERROR', previous?.message),
+      previousError: previous,
+    });
+  }
+
+  getUnsupportedValueException(method: keyof CacheInterface, v: unknown): UnsupportedValueException {
+    let json: string;
+    try {
+      json = JSON.stringify(v);
+    } catch (e) {
+      json = '<unparsable>';
+    }
+    return new UnsupportedValueException({
+      message: this.formatMsg(method, 'UNSUPPORTED_VALUE', `type: ${typeof v}, val: ${json}`),
+    });
+  }
+
+  getCacheException(method: keyof CacheInterface, reason: ErrorReasons, previous?: Error): CacheException {
+    return new CacheException({ message: this.formatMsg(method, reason, previous?.message), previousError: previous });
+  }
+}

--- a/packages/cache-interop/src/error/error-helper.ts
+++ b/packages/cache-interop/src/error/error-helper.ts
@@ -1,7 +1,12 @@
 import { ErrorFormatter } from './error-formatter';
 import { CacheInterface } from '../cache.interface';
 import { ErrorReasons } from './error.constants';
-import { CacheException, InvalidCacheKeyException, UnsupportedValueException } from '../exceptions';
+import {
+  CacheException,
+  InvalidCacheKeyException,
+  UnexpectedErrorException,
+  UnsupportedValueException,
+} from '../exceptions';
 
 export class ErrorHelper {
   private readonly formatter: ErrorFormatter;
@@ -33,6 +38,12 @@ export class ErrorHelper {
     }
     return new UnsupportedValueException({
       message: this.formatMsg(method, 'UNSUPPORTED_VALUE', `type: ${typeof v}, val: ${json}`),
+    });
+  }
+
+  getUnexpectedErrorException(method: keyof CacheInterface, previous?: Error): UnexpectedErrorException {
+    return new UnexpectedErrorException({
+      message: this.formatMsg(method, 'UNEXPECTED_ERROR', previous?.message),
     });
   }
 

--- a/packages/cache-interop/src/error/error-helper.ts
+++ b/packages/cache-interop/src/error/error-helper.ts
@@ -6,6 +6,7 @@ import {
   InvalidCacheKeyException,
   UnexpectedErrorException,
   UnsupportedValueException,
+  CacheProviderException,
 } from '../exceptions';
 
 export class ErrorHelper {
@@ -22,8 +23,8 @@ export class ErrorHelper {
     return new InvalidCacheKeyException({ key: key, message: this.formatMsg(method, 'INVALID_KEY') });
   }
 
-  getCacheProviderException(method: keyof CacheInterface, previous?: Error): CacheException {
-    return new CacheException({
+  getCacheProviderException(method: keyof CacheInterface, previous?: Error): CacheProviderException {
+    return new CacheProviderException({
       message: this.formatMsg(method, 'EXECUTE_ASYNC_ERROR', previous?.message),
       previousError: previous,
     });

--- a/packages/cache-interop/src/error/error-helper.ts
+++ b/packages/cache-interop/src/error/error-helper.ts
@@ -26,7 +26,7 @@ export class ErrorHelper {
   getCacheProviderException(method: keyof CacheInterface, previous?: Error): CacheProviderException {
     return new CacheProviderException({
       message: this.formatMsg(method, 'EXECUTE_ASYNC_ERROR', previous?.message),
-      previousError: previous,
+      previous: previous,
     });
   }
 
@@ -49,6 +49,6 @@ export class ErrorHelper {
   }
 
   getCacheException(method: keyof CacheInterface, reason: ErrorReasons, previous?: Error): CacheException {
-    return new CacheException({ message: this.formatMsg(method, reason, previous?.message), previousError: previous });
+    return new CacheException({ message: this.formatMsg(method, reason, previous?.message), previous: previous });
   }
 }

--- a/packages/cache-interop/src/error/error-helper.ts
+++ b/packages/cache-interop/src/error/error-helper.ts
@@ -1,5 +1,4 @@
-import { ErrorFormatter } from './error-formatter';
-import { CacheInterface } from '../cache.interface';
+import { ErrorFormatter, CallerMethod, MethodWithKey } from './error-formatter';
 import { ErrorReasons } from './error.constants';
 import {
   CacheException,
@@ -15,22 +14,22 @@ export class ErrorHelper {
     this.formatter = new ErrorFormatter(this.adapterName);
   }
 
-  formatMsg(method: keyof CacheInterface, reason: ErrorReasons, detail?: string | null): string {
+  formatMsg(method: CallerMethod, reason: ErrorReasons, detail?: string | null): string {
     return this.formatter.getMsg(method, reason, detail);
   }
 
-  getInvalidCacheKeyException(method: keyof CacheInterface, key: unknown): InvalidCacheKeyException {
-    return new InvalidCacheKeyException({ key: key, message: this.formatMsg(method, 'INVALID_KEY') });
+  getInvalidCacheKeyException([method, key]: MethodWithKey): InvalidCacheKeyException {
+    return new InvalidCacheKeyException({ key, message: this.formatMsg(method, 'INVALID_KEY') });
   }
 
-  getCacheProviderException(method: keyof CacheInterface, previous?: Error): CacheProviderException {
+  getCacheProviderException(method: CallerMethod, previous?: Error): CacheProviderException {
     return new CacheProviderException({
       message: this.formatMsg(method, 'EXECUTE_ASYNC_ERROR', previous?.message),
       previous: previous,
     });
   }
 
-  getUnsupportedValueException(method: keyof CacheInterface, v: unknown): UnsupportedValueException {
+  getUnsupportedValueException(method: CallerMethod, v: unknown): UnsupportedValueException {
     let json: string;
     try {
       json = JSON.stringify(v);
@@ -42,13 +41,13 @@ export class ErrorHelper {
     });
   }
 
-  getUnexpectedErrorException(method: keyof CacheInterface, previous?: Error): UnexpectedErrorException {
+  getUnexpectedErrorException(method: CallerMethod, previous?: Error): UnexpectedErrorException {
     return new UnexpectedErrorException({
       message: this.formatMsg(method, 'UNEXPECTED_ERROR', previous?.message),
     });
   }
 
-  getCacheException(method: keyof CacheInterface, reason: ErrorReasons, previous?: Error): CacheException {
+  getCacheException(method: CallerMethod, reason: ErrorReasons, previous?: Error): CacheException {
     return new CacheException({ message: this.formatMsg(method, reason, previous?.message), previous: previous });
   }
 }

--- a/packages/cache-interop/src/error/error.constants.ts
+++ b/packages/cache-interop/src/error/error.constants.ts
@@ -1,4 +1,5 @@
 export const errorReasons = {
+  INVALID_KEY: 'Invalid key argument',
   WRITE_ERROR: "Can't write to the cache",
   READ_ERROR: "Can't read from the cache",
   COMMAND_ERROR: "Can't execute operation",

--- a/packages/cache-interop/src/error/error.constants.ts
+++ b/packages/cache-interop/src/error/error.constants.ts
@@ -6,6 +6,7 @@ export const errorReasons = {
   EXECUTE_ASYNC_ERROR: "Can't execute async provider",
   UNEXPECTED_REPLY: 'Unexpected response from driver',
   UNSUPPORTED_VALUE: 'Unsupported value',
+  UNEXPECTED_ERROR: 'Unexpected error',
 } as const;
 
 export type ErrorReasons = keyof typeof errorReasons;

--- a/packages/cache-interop/src/error/error.constants.ts
+++ b/packages/cache-interop/src/error/error.constants.ts
@@ -1,0 +1,10 @@
+export const errorReasons = {
+  WRITE_ERROR: "Can't write to the cache",
+  READ_ERROR: "Can't read from the cache",
+  COMMAND_ERROR: "Can't execute operation",
+  EXECUTE_ASYNC_ERROR: "Can't execute async provider",
+  UNEXPECTED_REPLY: 'Unexpected response from driver',
+  UNSUPPORTED_VALUE: 'Unsupported value',
+} as const;
+
+export type ErrorReasons = keyof typeof errorReasons;

--- a/packages/cache-interop/src/exceptions/cache.exception.ts
+++ b/packages/cache-interop/src/exceptions/cache.exception.ts
@@ -1,34 +1,34 @@
 export type CacheExceptionProps = {
   message?: string;
-  previousError?: Error | null;
+  previous?: Error | null;
 };
 
 export class CacheException extends Error {
   public readonly props: CacheExceptionProps;
   public readonly stackTrace: string | null;
-  private _previousError!: Error | null;
+  private _previous!: Error | null;
 
-  get previousError(): Error | null {
-    return this._previousError ?? null;
+  get previous(): Error | null {
+    return this._previous ?? null;
   }
 
-  set previousError(previousError: Error | null) {
-    this._previousError = previousError;
-    if (previousError !== null) {
+  set previous(previous: Error | null) {
+    this._previous = previous;
+    if (previous !== null) {
       this.message = `${this.message}, innerException: ${
-        previousError.message.length > 0 ? previousError.message : previousError.name
+        previous.message.length > 0 ? previous.message : previous.name
       }`.trim();
     }
   }
 
   constructor(props: CacheExceptionProps) {
-    const { message, previousError = null } = props;
+    const { message, previous = null } = props;
     super(message);
     this.props = props;
     Object.setPrototypeOf(this, CacheException.prototype);
     this.name = CacheException.prototype.constructor.name;
-    this.stackTrace = previousError?.stack ?? null;
-    this.previousError = previousError ?? null;
+    this.stackTrace = previous?.stack ?? null;
+    this.previous = previous ?? null;
   }
 
   getName(): string {

--- a/packages/cache-interop/src/exceptions/index.ts
+++ b/packages/cache-interop/src/exceptions/index.ts
@@ -4,3 +4,4 @@ export { UnsupportedFeatureException } from './unsupported-feature.exception';
 export { CacheProviderException } from './cache-provider.exception';
 export { UnexpectedErrorException } from './unexpected-error.exception';
 export { InvalidCacheKeyException } from './invalid-cache-key-exception';
+export { UnsupportedValueException } from './unsupported-value.exception';

--- a/packages/cache-interop/src/exceptions/invalid-cache-key-exception.ts
+++ b/packages/cache-interop/src/exceptions/invalid-cache-key-exception.ts
@@ -9,7 +9,7 @@ export class InvalidCacheKeyException extends InvalidArgumentException {
   static readonly defaultMessage = 'InvalidArgument for cacheKey';
   private safeKey: string;
   constructor(props: Props) {
-    const { key, message, previousError } = props;
+    const { key, message, previous } = props;
     let safeKey: string;
     try {
       safeKey = JSON.stringify(key);
@@ -17,7 +17,7 @@ export class InvalidCacheKeyException extends InvalidArgumentException {
       safeKey = 'unknown';
     }
     const msg = message ? message : `${InvalidCacheKeyException.defaultMessage} (${safeKey})`;
-    super({ message: msg, previousError });
+    super({ message: msg, previous });
     this.safeKey = safeKey;
     Object.setPrototypeOf(this, InvalidCacheKeyException.prototype);
     this.name = InvalidCacheKeyException.prototype.constructor.name;

--- a/packages/cache-interop/src/exceptions/unsupported-value.exception.ts
+++ b/packages/cache-interop/src/exceptions/unsupported-value.exception.ts
@@ -1,0 +1,11 @@
+import { CacheException, CacheExceptionProps } from './cache.exception';
+
+type Props = CacheExceptionProps;
+
+export class UnsupportedValueException extends CacheException {
+  constructor(props: Props) {
+    super(props);
+    Object.setPrototypeOf(this, UnsupportedValueException.prototype);
+    this.name = UnsupportedValueException.prototype.constructor.name;
+  }
+}

--- a/packages/cache-interop/src/index.ts
+++ b/packages/cache-interop/src/index.ts
@@ -6,13 +6,17 @@ export { CacheItem } from './cache-item';
 export { CacheItemFactory } from './cache-item.factory';
 
 export * from './adapter';
-export * from './exceptions';
 export * from './serializer';
 export * from './eviction';
 
 // Value provider
 
 export { executeValueProviderFn } from './utils';
+
+// Errors & Exceptions
+
+export * from './exceptions';
+export { ErrorFormatter } from './error/error-formatter';
 
 // Connection related
 

--- a/packages/cache-interop/src/index.ts
+++ b/packages/cache-interop/src/index.ts
@@ -17,6 +17,7 @@ export { executeValueProviderFn } from './utils';
 
 export * from './exceptions';
 export { ErrorFormatter } from './error/error-formatter';
+export { ErrorHelper } from './error/error-helper';
 
 // Connection related
 

--- a/packages/cache-interop/src/validation/__tests__/guards.test.ts
+++ b/packages/cache-interop/src/validation/__tests__/guards.test.ts
@@ -1,6 +1,7 @@
 import { Guards } from '../guards';
 import { CacheInterface } from '../../cache.interface';
 import { ConnectedCacheInterface } from '../../connection/connected-cache.interface';
+import { CacheException, UnsupportedValueException } from '../../exceptions';
 
 describe('Guards tests', () => {
   describe('isNonEmptyString', () => {
@@ -18,8 +19,32 @@ describe('Guards tests', () => {
     });
   });
 
+  describe('isValidRedisValue', () => {
+    it('should work as expected', () => {
+      expect(Guards.isValidRedisValue(1)).toStrictEqual(true);
+      expect(Guards.isValidRedisValue(-3.2)).toStrictEqual(true);
+      expect(Guards.isValidRedisValue('')).toStrictEqual(true);
+      expect(Guards.isValidRedisValue('Hello')).toStrictEqual(true);
+      expect(Guards.isValidRedisValue(() => {})).toStrictEqual(false);
+      expect(Guards.isValidRedisValue(NaN)).toStrictEqual(false);
+      expect(Guards.isValidRedisValue(new Date())).toStrictEqual(false);
+      expect(Guards.isValidRedisValue(/.*/)).toStrictEqual(false);
+    });
+  });
+
+  describe('isCacheException', () => {
+    it('should work as expected', () => {
+      expect(Guards.isCacheException(new CacheException({ message: 't' }))).toStrictEqual(true);
+      expect(Guards.isCacheException(new UnsupportedValueException({ message: 't' }))).toStrictEqual(true);
+      expect(Guards.isCacheException(() => {})).toStrictEqual(false);
+      expect(Guards.isCacheException(NaN)).toStrictEqual(false);
+      expect(Guards.isCacheException(new Date())).toStrictEqual(false);
+      expect(Guards.isCacheException(/.*/)).toStrictEqual(false);
+    });
+  });
+
   describe('isCacheValueProviderFn', () => {
-    it('should work as exepted', () => {
+    it('should work as expected', () => {
       expect(Guards.isCacheValueProviderFn(() => {})).toStrictEqual(true);
       expect(Guards.isCacheValueProviderFn(async () => {})).toStrictEqual(true);
       expect(Guards.isCacheValueProviderFn(null)).toStrictEqual(false);

--- a/packages/cache-interop/src/validation/guards.ts
+++ b/packages/cache-interop/src/validation/guards.ts
@@ -1,8 +1,12 @@
 import { CacheInterface, CacheKey, CacheValueProviderFn } from '../cache.interface';
 import { isAsyncFn, isPromiseLike, isSyncFn } from '../utils';
 import { ConnectedCacheInterface } from '../connection/connected-cache.interface';
+import { CacheException } from '../exceptions';
 
 type CacheOrConnectedCache = CacheInterface | ConnectedCacheInterface<unknown>;
+
+// @todo find a way string | Buffer | number | any[]
+type ValidRedisValue = string | number;
 
 export class Guards {
   static isValidCacheKey<K extends CacheKey = CacheKey>(key: unknown): key is K {
@@ -17,8 +21,16 @@ export class Guards {
     return typeof ((adapter as unknown) as ConnectedCacheInterface<T>)?.getConnection === 'function';
   }
 
+  static isCacheException(val: unknown): val is CacheException {
+    return val instanceof CacheException;
+  }
+
   static isCacheValueProviderFn<T>(fn: unknown): fn is CacheValueProviderFn<T> {
     return isAsyncFn(fn) || isSyncFn(fn) || isPromiseLike(fn);
+  }
+
+  static isValidRedisValue(value: unknown): value is ValidRedisValue {
+    return ['string', 'number'].includes(typeof value) && !Number.isNaN(value);
   }
 
   static isNonEmptyString(value: unknown, trim = true): value is string {

--- a/packages/cache-interop/src/validation/guards.ts
+++ b/packages/cache-interop/src/validation/guards.ts
@@ -5,8 +5,10 @@ import { CacheException } from '../exceptions';
 
 type CacheOrConnectedCache = CacheInterface | ConnectedCacheInterface<unknown>;
 
-// @todo find a way string | Buffer | number | any[]
-type ValidRedisValue = string | number;
+// @todo find a way to get the best support
+//  - [ioredis] accepts: string | number | Buffer | number | any[]
+//  - [node-redis] accepts: string
+type ValidRedisValue = string;
 
 export class Guards {
   static isValidCacheKey<K extends CacheKey = CacheKey>(key: unknown): key is K {

--- a/packages/cache-ioredis/README.md
+++ b/packages/cache-ioredis/README.md
@@ -64,9 +64,10 @@ if (await cache.has('key')) {
 ### Connection
 
 IORedisAdapter `connection` param can be a dsn as string, an IORedisConnection,
-the native [IORedis.RedisOptions](https://github.com/luin/ioredis) or an existing [IORedis.Redis](https://github.com/luin/ioredis) connection.
+the native [IORedis.RedisOptions](https://github.com/luin/ioredis/blob/master/API.md#new-redisport-host-options) connection.
 
-> In some circumstances, DSN overrides can be applied thanks to the `getIoRedisOptionsFromDsn` function:
+> You can use the `getIoRedisOptionsFromDsn` function to initiate a connection
+> with native parameters.
 >
 > ```typescript
 > import { IoRedisCacheAdapter, getIoRedisOptionsFromDsn } from '@soluble/cache-ioredis';
@@ -75,9 +76,8 @@ the native [IORedis.RedisOptions](https://github.com/luin/ioredis) or an existin
 >
 > const cache = new IoRedisCacheAdapter({
 >   connection: getIoRedisOptionsFromDsn(dsn, {
->     overrides: {
->       db: 'db8',
->     },
+>     // here all io-redis params.
+>     connectTimeout: 1,
 >   }),
 > });
 > ```

--- a/packages/cache-ioredis/src/__tests__/ioredis-dsn.util.test.ts
+++ b/packages/cache-ioredis/src/__tests__/ioredis-dsn.util.test.ts
@@ -61,6 +61,35 @@ describe('ioredis-dsn utils', () => {
       });
     });
 
+    describe('when redisClient options are given', () => {
+      it('should return custom redis client options', () => {
+        const dsn = 'redis://localhost:6379';
+        expect(getIoRedisOptionsFromDsn(dsn, { connectTimeout: 1 })).toStrictEqual({
+          host: 'localhost',
+          connectTimeout: 1,
+          port: 6379,
+        });
+      });
+
+      it('should take precedence on dsnOverrides', () => {
+        const dsn = 'redis://localhost:6379';
+        expect(getIoRedisOptionsFromDsn(dsn, { port: 2015 }, { port: 2014 })).toStrictEqual({
+          host: 'localhost',
+          port: 2015,
+        });
+      });
+    });
+
+    describe('when dsnOverrides are given', () => {
+      it('should overwrite port when override say so', () => {
+        const dsn = 'redis://localhost:6379';
+        expect(getIoRedisOptionsFromDsn(dsn, undefined, { port: 2014 })).toStrictEqual({
+          host: 'localhost',
+          port: 2014,
+        });
+      });
+    });
+
     describe('when dsn is not parsable', () => {
       it('should throw expected message', () => {
         const dsn = 'redis://';

--- a/packages/cache-ioredis/src/ioredis-cache-adapter.ts
+++ b/packages/cache-ioredis/src/ioredis-cache-adapter.ts
@@ -63,16 +63,11 @@ export class IoRedisCacheAdapter<TBase = string, KBase extends CacheKey = CacheK
         error: this.errorHelper.getCacheException('get', 'READ_ERROR', e),
       });
     }
-    if (data === null) {
-      return CacheItemFactory.fromCacheMiss<T, K>({
-        key,
-        defaultValue,
-      });
-    }
+    const noData = data === null;
     return CacheItemFactory.fromOk<T, K>({
       key,
-      data,
-      isHit: true,
+      data: noData ? defaultValue : data,
+      isHit: !noData,
     });
   };
 

--- a/packages/cache-ioredis/src/ioredis-cache-adapter.ts
+++ b/packages/cache-ioredis/src/ioredis-cache-adapter.ts
@@ -82,7 +82,7 @@ export class IoRedisCacheAdapter<TBase = string, KBase extends CacheKey = CacheK
     options?: SetOptions
   ): Promise<boolean | CacheException> => {
     if (!Guards.isValidCacheKey(key)) {
-      return this.errorHelper.getInvalidCacheKeyException('set', key);
+      return this.errorHelper.getInvalidCacheKeyException(['set', key]);
     }
     const { ttl = 0, disableCache = false } = options ?? {};
     if (disableCache) {
@@ -112,7 +112,7 @@ export class IoRedisCacheAdapter<TBase = string, KBase extends CacheKey = CacheK
 
   has = async <K extends KBase = KBase>(key: K, options?: HasOptions): Promise<boolean | undefined> => {
     if (!Guards.isValidCacheKey(key)) {
-      options?.onError?.(this.errorHelper.getInvalidCacheKeyException('has', key));
+      options?.onError?.(this.errorHelper.getInvalidCacheKeyException(['has', key]));
       return undefined;
     }
     const { disableCache = false } = options ?? {};
@@ -130,7 +130,7 @@ export class IoRedisCacheAdapter<TBase = string, KBase extends CacheKey = CacheK
 
   delete = async <K extends KBase = KBase>(key: K, options?: DeleteOptions): Promise<boolean | CacheException> => {
     if (!Guards.isValidCacheKey(key)) {
-      return this.errorHelper.getInvalidCacheKeyException('set', key);
+      return this.errorHelper.getInvalidCacheKeyException(['delete', key]);
     }
     const { disableCache = false } = options ?? {};
     if (disableCache) {
@@ -153,7 +153,7 @@ export class IoRedisCacheAdapter<TBase = string, KBase extends CacheKey = CacheK
       });
   };
 
-  getConnection(): ConnectionInterface<IORedis.Redis> {
+  getConnection = (): ConnectionInterface<IORedis.Redis> => {
     return this.conn;
-  }
+  };
 }

--- a/packages/cache-ioredis/src/ioredis-cache-adapter.ts
+++ b/packages/cache-ioredis/src/ioredis-cache-adapter.ts
@@ -130,7 +130,7 @@ export class IoRedisCacheAdapter<TBase = string, KBase extends CacheKey = CacheK
 
   delete = async <K extends KBase = KBase>(key: K, options?: DeleteOptions): Promise<boolean | CacheException> => {
     if (!Guards.isValidCacheKey(key)) {
-      return new InvalidCacheKeyException({ key });
+      return this.errorHelper.getInvalidCacheKeyException('set', key);
     }
     const { disableCache = false } = options ?? {};
     if (disableCache) {

--- a/packages/cache-ioredis/src/ioredis-connection.ts
+++ b/packages/cache-ioredis/src/ioredis-connection.ts
@@ -8,9 +8,9 @@ export class IoredisConnection implements ConnectionInterface<IORedis.Redis> {
     this.ioRedis = ioRedis;
   }
 
-  async quit(): Promise<boolean> {
+  quit = async (): Promise<boolean> => {
     return this.ioRedis.quit().then((resp) => resp === 'OK');
-  }
+  };
 
   /**
    * Access directly the wrapped ioredis connection

--- a/packages/cache-redis/README.md
+++ b/packages/cache-redis/README.md
@@ -63,10 +63,11 @@ if (await cache.has('key')) {
 
 ### Connection
 
-RedisAdapter `connection` param can be a dsn as string, a RedisConnection,
-the native [ClientOpts](https://github.com/NodeRedis/node-redis) or an existing [RedisClient](https://github.com/NodeRedis/node-redis) connection.
+RedisAdapter `connection` param can be a DSN, a RedisConnection,
+the native [ClientOpts](https://github.com/NodeRedis/node-redis#options-object-properties) or an existing [RedisClient](https://github.com/NodeRedis/node-redis) connection.
 
-> In some circumstances, DSN overrides can be applied thanks to the `getIoRedisOptionsFromDsn` function:
+> You can use the `getRedisOptionsFromDsn` function to initiate a connection
+> with native parameters.
 >
 > ```typescript
 > import { RedisCacheAdapter, getRedisOptionsFromDsn } from '@soluble/cache-redis';
@@ -75,7 +76,7 @@ the native [ClientOpts](https://github.com/NodeRedis/node-redis) or an existing 
 >
 > const cache = new RedisCacheAdapter({
 >   connection: getRedisOptionsFromDsn(dsn, {
->     db: 'db0',
+>     // here all node-redis client options
 >     enable_offline_queue: false,
 >   }),
 > });

--- a/packages/cache-redis/README.md
+++ b/packages/cache-redis/README.md
@@ -75,9 +75,8 @@ the native [ClientOpts](https://github.com/NodeRedis/node-redis) or an existing 
 >
 > const cache = new RedisCacheAdapter({
 >   connection: getRedisOptionsFromDsn(dsn, {
->     overrides: {
->       db: 'db8',
->     },
+>     db: 'db0',
+>     enable_offline_queue: false,
 >   }),
 > });
 > ```

--- a/packages/cache-redis/src/__tests__/redis-dsn.util.test.ts
+++ b/packages/cache-redis/src/__tests__/redis-dsn.util.test.ts
@@ -36,9 +36,31 @@ describe('redis-dsn utils', () => {
           host: 'localhost',
         });
       });
-      it('should honour overrides', () => {
+    });
+
+    describe('when redisClient options are given', () => {
+      it('should return custom redis client options', () => {
         const dsn = 'redis://localhost:6379';
-        expect(getRedisOptionsFromDsn(dsn, { port: 2014 })).toStrictEqual({
+        expect(getRedisOptionsFromDsn(dsn, { no_ready_check: true })).toStrictEqual({
+          host: 'localhost',
+          no_ready_check: true,
+          port: 6379,
+        });
+      });
+
+      it('should take precedence on dsnOverrides', () => {
+        const dsn = 'redis://localhost:6379';
+        expect(getRedisOptionsFromDsn(dsn, { port: 2015 }, { port: 2014 })).toStrictEqual({
+          host: 'localhost',
+          port: 2015,
+        });
+      });
+    });
+
+    describe('when dsnOverrides are given', () => {
+      it('should overwrite port when override say so', () => {
+        const dsn = 'redis://localhost:6379';
+        expect(getRedisOptionsFromDsn(dsn, undefined, { port: 2014 })).toStrictEqual({
           host: 'localhost',
           port: 2014,
         });

--- a/packages/cache-redis/src/redis-async.util.ts
+++ b/packages/cache-redis/src/redis-async.util.ts
@@ -5,10 +5,11 @@ export type AsyncRedisClient = ReturnType<typeof getAsyncRedisClient>;
 
 export const getAsyncRedisClient = (redis: RedisClient) => {
   return {
-    flushdb: promisify(redis.flushdb).bind(redis),
+    get: promisify(redis.get).bind(redis),
     set: promisify(redis.set).bind(redis),
     setex: promisify(redis.setex).bind(redis),
     exists: promisify(redis.exists).bind(redis) as (k: string) => Promise<number>,
     del: promisify(redis.del).bind(redis) as (k: string) => Promise<number>,
+    flushdb: promisify(redis.flushdb).bind(redis),
   };
 };

--- a/packages/cache-redis/src/redis-async.util.ts
+++ b/packages/cache-redis/src/redis-async.util.ts
@@ -1,0 +1,14 @@
+import { RedisClient } from 'redis';
+import { promisify } from 'util';
+
+export type AsyncRedisClient = ReturnType<typeof getAsyncRedisClient>;
+
+export const getAsyncRedisClient = (redis: RedisClient) => {
+  return {
+    flushdb: promisify(redis.flushdb).bind(redis),
+    set: promisify(redis.set).bind(redis),
+    setex: promisify(redis.setex).bind(redis),
+    exists: promisify(redis.exists).bind(redis) as (k: string) => Promise<number>,
+    del: promisify(redis.del).bind(redis) as (k: string) => Promise<number>,
+  };
+};

--- a/packages/cache-redis/src/redis-cache-adapter.ts
+++ b/packages/cache-redis/src/redis-cache-adapter.ts
@@ -72,16 +72,11 @@ export class RedisCacheAdapter<TBase = string, KBase extends CacheKey = CacheKey
         error: this.errorHelper.getCacheException('get', 'READ_ERROR', e),
       });
     }
-    if (data === null) {
-      return CacheItemFactory.fromCacheMiss<T, K>({
-        key,
-        defaultValue,
-      });
-    }
+    const noData = data === null;
     return CacheItemFactory.fromOk<T, K>({
       key,
-      data,
-      isHit: true,
+      data: noData ? defaultValue : data,
+      isHit: !noData,
     });
   };
 

--- a/packages/cache-redis/src/redis-cache-adapter.ts
+++ b/packages/cache-redis/src/redis-cache-adapter.ts
@@ -66,21 +66,6 @@ export class RedisCacheAdapter<TBase = string, KBase extends CacheKey = CacheKey
     let data: T;
     try {
       data = ((await this.asyncRedis.get(key)) as unknown) as T;
-      /*
-      const pm = async () => {
-        return new Promise((resolve, reject) => {
-          this.redis.get(key, (err, reply) => {
-            if (err) {
-              reject('Ta mère');
-            }
-            resolve(reply);
-          });
-        });
-      };
-
-      data = await pm();
-      *
-       */
     } catch (e) {
       return CacheItemFactory.fromErr<K>({
         key,
@@ -99,6 +84,7 @@ export class RedisCacheAdapter<TBase = string, KBase extends CacheKey = CacheKey
       isHit: true,
     });
   };
+
   set = async <T = TBase, K extends KBase = KBase>(
     key: K,
     value: T | CacheValueProviderFn<T>,

--- a/packages/cache-redis/src/redis-connection.ts
+++ b/packages/cache-redis/src/redis-connection.ts
@@ -12,7 +12,7 @@ export class RedisConnection implements ConnectionInterface<RedisClient> {
 
   quit = async (): Promise<boolean> => {
     const asyncQuit = promisify(this.redis.quit).bind(this.redis);
-    return await asyncQuit()
+    return asyncQuit()
       .then((reply) => reply === 'OK')
       .catch((e) => {
         return false;

--- a/packages/cache-redis/src/redis-connection.ts
+++ b/packages/cache-redis/src/redis-connection.ts
@@ -1,6 +1,7 @@
 import { ConnectionInterface } from '@soluble/cache-interop';
 
 import { RedisClient } from 'redis';
+import { promisify } from 'util';
 
 export class RedisConnection implements ConnectionInterface<RedisClient> {
   private readonly redis: RedisClient;
@@ -9,17 +10,14 @@ export class RedisConnection implements ConnectionInterface<RedisClient> {
     this.redis = redis;
   }
 
-  async quit(): Promise<boolean> {
-    return new Promise((resolve, reject) => {
-      this.redis.quit((err, reply) => {
-        if (err instanceof Error) {
-          reject(err.message);
-          return;
-        }
-        resolve(reply === 'OK');
+  quit = async (): Promise<boolean> => {
+    const asyncQuit = promisify(this.redis.quit).bind(this.redis);
+    return await asyncQuit()
+      .then((reply) => reply === 'OK')
+      .catch((e) => {
+        return false;
       });
-    });
-  }
+  };
 
   /**
    * Access directly the wrapped ioredis connection

--- a/packages/cache-redis/src/redis-dsn.util.ts
+++ b/packages/cache-redis/src/redis-dsn.util.ts
@@ -16,7 +16,7 @@ export const getTlsOptions = (driver: string, host: string): ConnectionOptions |
  * Converts a soluble/dsn-parser dsn into Redis.Options
  * @link https://github.com/soluble-io/cache-interop/tree/main/packages/dsn-parser
  *
- * @throws Error id dsn is invalid or cannot be parsed
+ * @throws Error if dsn is invalid or cannot be parsed
  */
 export const getRedisOptionsFromDsn = (dsn: string, overrides?: ParseDsnOptions['overrides']): RedisClientOptions => {
   const parsed = parseDsn(dsn, {

--- a/packages/cache-redis/src/redis-dsn.util.ts
+++ b/packages/cache-redis/src/redis-dsn.util.ts
@@ -25,7 +25,7 @@ export const getTlsOptions = (driver: string, host: string): ConnectionOptions |
  */
 export const getRedisOptionsFromDsn = (
   dsn: string,
-  clientOptions?: Partial<Omit<RedisClientOptions, 'url'>>,
+  clientOptions?: Partial<Omit<RedisClientOptions, 'url'>> & { url?: never },
   dsnOverrides?: ParseDsnOptions['overrides']
 ): RedisClientOptions => {
   const parsed = parseDsn(dsn, {


### PR DESCRIPTION
## Purpose 

Error messages should not vary between implementations.

From next version the following constants will be defined

```typescript
export const errorReasons = {
  WRITE_ERROR: "Can't write to the cache",
  READ_ERROR: "Can't read from the cache",
  COMMAND_ERROR: "Can't execute operation",
  EXECUTE_ASYNC_ERROR: "Can't execute async provider",
  UNEXPECTED_REPLY: 'Unexpected response from driver',
  UNSUPPORTED_VALUE: 'Unsupported value',
} as const;
```

and used through a common formatter:

```
[IoRedisCacheAdapter.has()] COMMAND_ERROR: Can't execute operation (Rea....
```

## Tasks

todo

- [ ] Refactor previousError in previous
- [ ] ...