### PR TITLE
chore(ignore): ignore .netrc produced by changeset/action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ tsconfig.tsbuildinfo
 /coverage
 /.nyc_output
 
+# changeset
+# this file is generated in the changeset/action
+.netrc
+
 # editor
 /.idea
 .project


### PR DESCRIPTION
Latest `changeset/action` creates a `.netrc` file causing this 

![image](https://user-images.githubusercontent.com/259798/152820645-66d19361-9faf-4c07-b0d0-38b61b59114d.png)


PS: Left a note here https://github.com/changesets/action/issues/148