### PR TITLE
ci(changeset): explicit git user

### DIFF
--- a/.github/workflows/release-or-pr-version.yml
+++ b/.github/workflows/release-or-pr-version.yml
@@ -47,6 +47,10 @@ jobs:
         run: |
           cat ${{ github.workspace }}/.npmrc
 
+      - run: |
+          git config --global user.email "belgattitude@gmail.com"
+          git config --global user.name "Sébastien Vanvelthem"
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1.2.0


### PR DESCRIPTION
Some things broke on changeset/action 1.2.0.

So to be able to run actions on the version P/R, we need an user that have a `workflow` in its scope.