### PR TITLE
test: add dragonfly to e2e tests

### DIFF
--- a/packages/cache-e2e-tests/test/setup/E2eDockerContainers.ts
+++ b/packages/cache-e2e-tests/test/setup/E2eDockerContainers.ts
@@ -5,6 +5,10 @@ import { GenericContainer } from 'testcontainers';
 const registeredE2eContainers = {
   redis6: { image: 'redis:6-alpine3.18', port: 6379 },
   redis7: { image: 'redis:7-alpine3.18', port: 6379 },
+  dragonflyLatest: {
+    image: 'docker.dragonflydb.io/dragonflydb/dragonfly',
+    port: 6379,
+  },
 } as const;
 
 type ContainerKey = keyof typeof registeredE2eContainers;

--- a/packages/cache-e2e-tests/test/setup/getTestAdapters.ts
+++ b/packages/cache-e2e-tests/test/setup/getTestAdapters.ts
@@ -46,6 +46,17 @@ export const getTestAdapters = () => {
         });
       },
     ],
+    [
+      'RedisCacheAdapter/DragonflyLatest',
+      async () => {
+        const { dsn } = await E2eDockerContainers.getContainer(
+          'dragonflyLatest'
+        );
+        return new RedisCacheAdapter({
+          connection: dsn,
+        });
+      },
+    ],
   ] as [
     name: string,
     factory: () => CacheInterface | Promise<CacheInterface>


### PR DESCRIPTION
Add dragonfly to the e2e tests

will close https://github.com/soluble-io/cache-interop/issues/799