### PR TITLE
[dsn-parser]  give precedence to esm build

### DIFF
--- a/.changeset/beige-actors-hang.md
+++ b/.changeset/beige-actors-hang.md
@@ -1,0 +1,11 @@
+---
+"@soluble/dsn-parser": patch
+---
+
+Give precedence to esm
+
+Ensure the "module" condition comes before the "require" condition. Due to the way conditions are matched top-to-bottom,
+the "module" condition (used in bundler contexts only) must come before a "require" condition,
+so it has the opportunity to take precedence.
+
+See [publint](https://publint.dev/rules#exports_module_should_precede_require)

--- a/packages/dsn-parser/package.json
+++ b/packages/dsn-parser/package.json
@@ -24,8 +24,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "require": "./dist/index.js",
       "module": "./dist/index.mjs",
+      "require": "./dist/index.js",
       "import": "./dist/index.mjs",
       "browser": "./dist/index.mjs",
       "default": "./dist/index.js"


### PR DESCRIPTION
https://publint.dev/rules#exports_module_should_precede_require

EXPORTS_MODULE_SHOULD_PRECEDE_REQUIRE
Ensure the "module" condition comes before the "require" condition. Due to the way conditions are matched top-to-bottom, the "module" condition (used in bundler contexts only) must come before a "require" condition, so it has the opportunity to take precedence.